### PR TITLE
move dependencies to peerDependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 ## install
 
 ```
-yarn add nestjs-kysely
+yarn add nestjs-kysely kysely
 ```
 
 ## Example
 
 ```
-yarn add nestjs-kysely mysql2
+yarn add nestjs-kysely kysely mysql2
 ```
 
 Register KyselyModule for your app.

--- a/example/package.json
+++ b/example/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^8.0.0",
     "@nestjs/core": "^8.0.0",
     "@nestjs/platform-express": "^8.0.0",
+    "kysely": "^0.24.2",
     "mysql2": "^2.3.3",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3470,6 +3470,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+kysely@^0.24.2:
+  version "0.24.2"
+  resolved "https://registry.yarnpkg.com/kysely/-/kysely-0.24.2.tgz#caf3be037939bd20449c0b7840e932f074b4d12c"
+  integrity sha512-+7eaTJNUYm2yRq1x+lEOZc+78TO35dTZ9b0dh49+Z9CTt2byMSbMiOKpwPlOyCAaHD4kILkAYWYZNywFlmBwRA==
+
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"

--- a/package.json
+++ b/package.json
@@ -25,23 +25,28 @@
     "clean": "rimraf ./dist",
     "format": "deno fmt -c deno.jsonc",
     "lint": "deno lint -c deno.jsonc",
-    "test": "jest"
+    "test": "jest",
+    "prepublishOnly": "yarn build"
   },
-  "dependencies": {
-    "@nestjs/common": "^9.2.1",
-    "@nestjs/core": "^9.2.1",
-    "kysely": "^0.22.0",
-    "mysql2": "^2.3.3",
-    "pg": "^8.8.0",
+  "peerDependencies": {
+    "@nestjs/common": "^8.0.0 || ^9.0.0",
+    "@nestjs/core": "^8.0.0 || ^9.0.0",
+    "kysely": "^0.24.2",
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
+    "@nestjs/common": "^9.2.1",
+    "@nestjs/core": "^9.2.1",
     "@nestjs/testing": "^9.2.1",
     "@types/jest": "^29.2.4",
     "@types/pg": "^8.6.6",
     "husky": "^8.0.2",
     "jest": "^29.3.1",
+    "kysely": "^0.24.2",
     "lint-staged": "^13.1.0",
+    "mysql2": "^2.3.3",
+    "pg": "^8.8.0",
+    "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.0.3",
     "typescript": "^4.9.4"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@nestjs/common": "^8.0.0 || ^9.0.0",
     "@nestjs/core": "^8.0.0 || ^9.0.0",
-    "kysely": "^0.24.2",
+    "kysely": "0.x",
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1845,10 +1845,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-kysely@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/kysely/-/kysely-0.22.0.tgz#8aac53942da3cadc604d7d154a746d983fe8f7b9"
-  integrity sha512-ZE3qWtnqLOalodzfK5QUEcm7AEulhxsPNuKaGFsC3XiqO92vMLm+mAHk/NnbSIOtC4RmGm0nsv700i8KDp1gfQ==
+kysely@^0.24.2:
+  version "0.24.2"
+  resolved "https://registry.yarnpkg.com/kysely/-/kysely-0.24.2.tgz#caf3be037939bd20449c0b7840e932f074b4d12c"
+  integrity sha512-+7eaTJNUYm2yRq1x+lEOZc+78TO35dTZ9b0dh49+Z9CTt2byMSbMiOKpwPlOyCAaHD4kILkAYWYZNywFlmBwRA==
 
 leven@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Thank you for this library! 🙏 

This PR moves things to peerDependencies & devDependencies.

For reference:
https://github.com/nestjs/typeorm/blob/master/package.json

Current situation:
- limits consumers to kysely 0.22.0, and forces `nestjs-kysely` releases for each new kysely release.
- produces duplicate packages in consumers' `node_modules`.