### PR TITLE
docs: incorrect type annotation of injected db instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ You can then inject the Kysely client into any of your injectables by using a cu
 ```ts
 import { Controller, Get } from "@nestjs/common";
 import { InjectKysely } from "nestjs-kysely";
+import { Kysely } from 'kysely';
 import { DB } from "./@types";
 
 @Controller()
 export class AppController {
-  constructor(@InjectKysely() private readonly db: DB) {}
+  constructor(@InjectKysely() private readonly db: Kysely<DB>) {}
 
   @Get()
   async getHello(): Promise<string> {
@@ -161,6 +162,7 @@ You can then inject the Kysely client into any of your injectables by using a cu
 ```ts
 import { Controller, Get } from "@nestjs/common";
 import { InjectKysely } from "nestjs-kysely";
+import { Kysely } from 'kysely';
 import { DB } from "./@types";
 
 @Controller()


### PR DESCRIPTION
In most generators, the `DB` interface represents the database schema, not the injected instance itself. However, the current README uses `DB` to annotate the injected instance, which might lead to confusion.  

Some generators also create a `Database` interface that corresponds to the actual instance type, but this isn't universally true across all generators. Regardless of the generator, the correct type for the instance is always `Kysely<DB>`.  

This PR updates the README to reflect the proper usage.